### PR TITLE
Include LICENSE.md file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ summary = Matching paths against globs
 description-file = README.md
 home-page = https://gtihub.com/vidartf/globmatch
 license = BSD-3
+license_file = LICENSE.md
 classifier =
     Intended Audience :: Developers
     Intended Audience :: System Administrators


### PR DESCRIPTION
The license requires that all copies of the software include the license.  This makes sure the license is included in the wheels.  See the wheel documentation [here](https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file) for more information.